### PR TITLE
Minor change to public id filter

### DIFF
--- a/get_test.sh
+++ b/get_test.sh
@@ -13,6 +13,6 @@ echo "Your public_IDs are...(did ids.txt come back result in an empty file? make
 curl -sX GET "https://api.datadoghq.com/api/v1/synthetics/tests" \
 -H "Accept: application/json" \
 -H "DD-API-KEY: ${DD_API_KEY}" \
--H "DD-APPLICATION-KEY: ${DD_APP_KEY}" | jq . | grep public_id | sed 's/\"public_id": "//g' | sed 's/\",//g' > ids.txt
+-H "DD-APPLICATION-KEY: ${DD_APP_KEY}" | jq -r '.tests[].public_id' > ids.txt
 echo "\n" 
 


### PR DESCRIPTION
This change will use only `jq` for the filtering the `public_id` from the response instead of needing to use other tools.